### PR TITLE
Fix 3D LUT color byte order (RGB <-> BGR)

### DIFF
--- a/Projects/CMNEdit/Windows/Common/DE/DEElementColorCorrectionWindow.cs
+++ b/Projects/CMNEdit/Windows/Common/DE/DEElementColorCorrectionWindow.cs
@@ -4,6 +4,7 @@ using System;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using System.Windows.Forms;
@@ -55,7 +56,7 @@ namespace CMNEdit.Windows.Common.DE
                                 byte[] buf = new byte[reader.BaseStream.Length - 54];
                                 reader.BaseStream.Position += 54;
                                 reader.BaseStream.Read(buf, 0, buf.Length);
-                                correction.unkBytes = buf;
+                                correction.unkBytes = buf.Chunk(3).Select((x) => x.Reverse()).SelectMany(x => x).ToArray();
                             }
                         }
                     }

--- a/Projects/CMNEdit/Windows/Common/DE/DEElementColorCorrectionWindow2.cs
+++ b/Projects/CMNEdit/Windows/Common/DE/DEElementColorCorrectionWindow2.cs
@@ -4,6 +4,7 @@ using System;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using System.Windows.Forms;
@@ -45,7 +46,7 @@ namespace CMNEdit.Windows
                                 byte[] buf = new byte[reader.BaseStream.Length - 54];
                                 reader.BaseStream.Position += 54;
                                 reader.BaseStream.Read(buf, 0, buf.Length);
-                                correction.unkBytes = buf;
+                                correction.unkBytes = buf.Chunk(3).Select((x) => x.Reverse()).SelectMany(x => x).ToArray();
                             }
                         }
                     }

--- a/Types/Node/Element/DE/DEColorCorrection.cs
+++ b/Types/Node/Element/DE/DEColorCorrection.cs
@@ -118,7 +118,9 @@ namespace HActLib
                     }
 
                     bw.Write(bmpHeader2);
-                    bw.Write(unkBytes);
+
+                    // This basically flips pairs of 3 for it to go from RGB to BGR
+                    bw.Write(unkBytes.Chunk(3).Select((x) => x.Reverse()).SelectMany(x => x).ToArray());
                 }
 
                 return ms.GetBuffer();

--- a/Types/Node/Element/DE/DEElementColorCorrection2.cs
+++ b/Types/Node/Element/DE/DEElementColorCorrection2.cs
@@ -63,7 +63,7 @@ namespace HActLib
                     }
 
                     bw.Write(bmpHeader2);
-                    bw.Write(unkBytes);
+                    bw.Write(unkBytes.Chunk(3).Select((x) => x.Reverse()).SelectMany(x => x).ToArray());
                 }
 
                 return ms.GetBuffer();


### PR DESCRIPTION
Fixes 3D Lut Importing/Exporting/Viewing by making bmp data swap the byte order (BGR) when transitioning from cud data (RGB).